### PR TITLE
[BUGFIX] field name will not update if combinedName is empty

### DIFF
--- a/Classes/Hooks/DataHandler/BackwardsCompatibilityNameFormat.php
+++ b/Classes/Hooks/DataHandler/BackwardsCompatibilityNameFormat.php
@@ -54,9 +54,7 @@ class BackwardsCompatibilityNameFormat
                     $newRecord['last_name']
                 ));
 
-                if (!empty($combinedName)) {
-                    $fieldArray['name'] = $combinedName;
-                }
+                $fieldArray['name'] = $combinedName;
             }
         }
     }


### PR DESCRIPTION
If there was already a value in the field "name" and it's set to read only, the value is not updated if i clear all three fields "first_name", "middle_name" and "last_name".
The name field still contains it's last stored value.
In this case I would excpect that the field is cleared too.

This change will fix that "problem".